### PR TITLE
styl/petmiliyGPT

### DIFF
--- a/lib/screens/petmiliy_gpt_screen.dart
+++ b/lib/screens/petmiliy_gpt_screen.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+class PetmiliyGPTScreen extends StatelessWidget {
+  const PetmiliyGPTScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final dynamicColor = Theme.of(context).colorScheme;
+    final width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
+    if (Platform.isIOS) {
+      ///쿠퍼티노 디자인을 적용합니다.
+      return const Scaffold(
+        body: Text("iOS"),
+      );
+    } else {
+      ///머티리얼 디자인을 적용합니다.
+      return Scaffold(
+        backgroundColor: dynamicColor.surface,
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            HeaderWidget(
+              color: dynamicColor.surfaceVariant,
+            ),
+            const Text("Android"),
+          ],
+        ),
+        bottomNavigationBar: BottomAppBar(
+          color: dynamicColor.surfaceVariant,
+          elevation: 2.0,
+          child: Row(
+            children: <Widget>[
+              IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.arrow_back_rounded),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+  }
+}
+
+class HeaderWidget extends StatelessWidget {
+  const HeaderWidget({Key? key, required this.color}) : super(key: key);
+  final Color color;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(color: color),
+      child: const Text("GPT"),
+    );
+  }
+}

--- a/lib/screens/petmiliy_gpt_screen.dart
+++ b/lib/screens/petmiliy_gpt_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-
 import 'package:flutter/material.dart';
+import 'package:petmily/widgets/variable_text.dart';
 
 class PetmiliyGPTScreen extends StatelessWidget {
   const PetmiliyGPTScreen({super.key});
@@ -11,22 +11,24 @@ class PetmiliyGPTScreen extends StatelessWidget {
     final width = MediaQuery.of(context).size.width;
     final height = MediaQuery.of(context).size.height;
     if (Platform.isIOS) {
-      ///쿠퍼티노 디자인을 적용합니다.
+      ///TODO: 쿠퍼티노 디자인을 적용해야 합니다.
       return const Scaffold(
         body: Text("iOS"),
       );
     } else {
       ///머티리얼 디자인을 적용합니다.
       return Scaffold(
-        backgroundColor: dynamicColor.surface,
-        body: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            HeaderWidget(
-              color: dynamicColor.surfaceVariant,
-            ),
-            const Text("Android"),
-          ],
+        backgroundColor: dynamicColor.surfaceVariant,
+        body: SafeArea(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: <Widget>[
+              HeaderContentWidget(
+                color: dynamicColor.surfaceVariant,
+              ),
+              const BodyContentWidget()
+            ],
+          ),
         ),
         bottomNavigationBar: BottomAppBar(
           color: dynamicColor.surfaceVariant,
@@ -34,7 +36,9 @@ class PetmiliyGPTScreen extends StatelessWidget {
           child: Row(
             children: <Widget>[
               IconButton(
-                onPressed: () {},
+                onPressed: () {
+                  //TODO: 이전 화면으로 이동하도록 구성해야 합니다.
+                },
                 icon: const Icon(Icons.arrow_back_rounded),
               ),
             ],
@@ -45,15 +49,89 @@ class PetmiliyGPTScreen extends StatelessWidget {
   }
 }
 
-class HeaderWidget extends StatelessWidget {
-  const HeaderWidget({Key? key, required this.color}) : super(key: key);
+class HeaderContentWidget extends StatelessWidget {
+  const HeaderContentWidget({Key? key, required this.color}) : super(key: key);
+
   final Color color;
+
   @override
   Widget build(BuildContext context) {
+    final dynamicColor = Theme.of(context).colorScheme;
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(color: color),
-      child: const Text("GPT"),
+      child: Center(
+        child: VariableText(
+          value: "GPT",
+          color: dynamicColor.primary,
+          size: 40.0,
+          wght: 700.0,
+        ),
+      ),
+    );
+  }
+}
+
+class BodyContentWidget extends StatefulWidget {
+  const BodyContentWidget({super.key});
+
+  @override
+  State<BodyContentWidget> createState() => _BodyContentWidgetState();
+}
+
+class _BodyContentWidgetState extends State<BodyContentWidget> {
+  final _inputTextController = TextEditingController();
+  final _bodyContentScrollController = ScrollController();
+  final bool isLoading = false;
+  @override
+  void initState() {
+    super.initState;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        children: [inputFormField(), sendButton()],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _inputTextController.clear();
+    super.dispose();
+  }
+
+  Expanded inputFormField() {
+    return Expanded(
+      child: TextFormField(
+        textCapitalization: TextCapitalization.sentences,
+        controller: _inputTextController,
+        decoration: InputDecoration(
+          fillColor: Theme.of(context).colorScheme.inverseSurface,
+          filled: true,
+          hintText: "메세지를 입력하세요.",
+          border: InputBorder.none,
+          focusedBorder: InputBorder.none,
+          enabledBorder: InputBorder.none,
+          errorBorder: InputBorder.none,
+          disabledBorder: InputBorder.none,
+        ),
+      ),
+    );
+  }
+
+  Widget sendButton() {
+    return Visibility(
+      visible: !isLoading,
+      child: IconButton(
+        onPressed: () {
+          //TODO: inputTextController.text의 값을 감지하고, 전송 및 초기화를 담당해야 합니다.
+        },
+        icon: const Icon(Icons.subdirectory_arrow_left_rounded),
+      ),
     );
   }
 }

--- a/lib/screens/petmily_gpt_screen.dart
+++ b/lib/screens/petmily_gpt_screen.dart
@@ -8,8 +8,6 @@ class PetmilyGPTScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dynamicColor = Theme.of(context).colorScheme;
-    final width = MediaQuery.of(context).size.width;
-    final height = MediaQuery.of(context).size.height;
     if (Platform.isIOS) {
       ///TODO: 쿠퍼티노 디자인을 적용해야 합니다.
       return const Scaffold(
@@ -18,15 +16,17 @@ class PetmilyGPTScreen extends StatelessWidget {
     } else {
       ///머티리얼 디자인을 적용합니다.
       return Scaffold(
-        backgroundColor: dynamicColor.surfaceVariant,
+        backgroundColor: dynamicColor.surface,
+        resizeToAvoidBottomInset: false,
         body: SafeArea(
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               HeaderContentWidget(
                 color: dynamicColor.surfaceVariant,
               ),
-              const BodyContentWidget()
+              const TipContentWidget(),
+              const BodyContentWidget(),
             ],
           ),
         ),
@@ -44,6 +44,9 @@ class PetmilyGPTScreen extends StatelessWidget {
             ],
           ),
         ),
+        persistentFooterButtons: const <Widget>[
+          //TODO: Form field를 적용할 수 있도록 시도해봅니다.
+        ],
       );
     }
   }
@@ -57,15 +60,57 @@ class HeaderContentWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dynamicColor = Theme.of(context).colorScheme;
-    return Container(
-      width: double.infinity,
-      decoration: BoxDecoration(color: color),
-      child: Center(
-        child: VariableText(
-          value: "GPT",
-          color: dynamicColor.primary,
-          size: 40.0,
-          wght: 700.0,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: SizedBox(
+            width: double.infinity,
+            child: VariableText(
+              value: "대화하기",
+              color: dynamicColor.primary,
+              size: 40.0,
+              wght: 300.0,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class TipContentWidget extends StatelessWidget {
+  const TipContentWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final dynamicColor = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Container(
+        padding: const EdgeInsets.all(8.0),
+        width: 370.0,
+        height: 35,
+        decoration: BoxDecoration(
+          color: dynamicColor.tertiaryContainer,
+          borderRadius: BorderRadius.circular(5.0),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Icon(
+              Icons.tips_and_updates,
+              color: dynamicColor.tertiary,
+              size: 20.0,
+            ),
+            VariableText(
+              value: "부적절한 단어나 다른 주제의 질문은 답변하지 않습니다.",
+              color: dynamicColor.tertiary,
+              size: 15.0,
+              wght: 500.0,
+            ),
+          ],
         ),
       ),
     );
@@ -92,8 +137,19 @@ class _BodyContentWidgetState extends State<BodyContentWidget> {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: Row(
-        children: [inputFormField(), sendButton()],
+      child: Column(
+        children: [
+          SingleChildScrollView(
+            child: inputOutputListView(),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              inputFormField(),
+              sendButton(),
+            ],
+          ),
+        ],
       ),
     );
   }
@@ -104,13 +160,13 @@ class _BodyContentWidgetState extends State<BodyContentWidget> {
     super.dispose();
   }
 
-  Expanded inputFormField() {
+  Widget inputFormField() {
     return Expanded(
       child: TextFormField(
         textCapitalization: TextCapitalization.sentences,
         controller: _inputTextController,
         decoration: InputDecoration(
-          fillColor: Theme.of(context).colorScheme.inverseSurface,
+          fillColor: Theme.of(context).colorScheme.surfaceVariant,
           filled: true,
           hintText: "메세지를 입력하세요.",
           border: InputBorder.none,
@@ -130,8 +186,30 @@ class _BodyContentWidgetState extends State<BodyContentWidget> {
         onPressed: () {
           //TODO: inputTextController.text의 값을 감지하고, 전송 및 초기화를 담당해야 합니다.
         },
-        icon: const Icon(Icons.subdirectory_arrow_left_rounded),
+        icon: Icon(
+          Icons.subdirectory_arrow_left_rounded,
+          color: Theme.of(context).colorScheme.primary,
+        ),
       ),
+    );
+  }
+
+  Widget inputOutputListView() {
+    return ListView(
+      scrollDirection: Axis.vertical,
+      shrinkWrap: true,
+      children: const <Widget>[
+        SizedBox(
+          height: 380.0,
+          child: Center(
+            child: VariableText(
+              value: "대화를 시작하면 내용이 나타납니다.",
+              size: 12.0,
+              wght: 300.0,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/petmily_gpt_screen.dart
+++ b/lib/screens/petmily_gpt_screen.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:petmily/widgets/variable_text.dart';
 
-class PetmiliyGPTScreen extends StatelessWidget {
-  const PetmiliyGPTScreen({super.key});
+class PetmilyGPTScreen extends StatelessWidget {
+  const PetmilyGPTScreen({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/utilities/dynamic_theme.dart
+++ b/lib/utilities/dynamic_theme.dart
@@ -1,19 +1,23 @@
 import 'package:flutter/material.dart';
 
-class DynamicTheme {
-  static const _seedColor = Color(0XFFF6F1C4);
+const _seedColor = Color(0XFFBDB76B);
 
+class DynamicTheme {
   static ThemeData lightTheme(ColorScheme? lightColorScheme) {
-    ColorScheme defaultLightColorScheme = lightColorScheme ?? ColorScheme.fromSeed(seedColor: _seedColor, brightness: Brightness.light);
+    ColorScheme defaultLightColorScheme = lightColorScheme ??
+        ColorScheme.fromSeed(
+            seedColor: _seedColor, brightness: Brightness.light);
     return ThemeData(
       colorScheme: defaultLightColorScheme,
       useMaterial3: true,
       fontFamily: "PretendardVariation",
-    );  
+    );
   }
 
   static ThemeData darkTheme(ColorScheme? darkColorScheme) {
-    ColorScheme defaultDarkColorScheme = darkColorScheme ?? ColorScheme.fromSeed(seedColor: _seedColor, brightness: Brightness.dark);
+    ColorScheme defaultDarkColorScheme = darkColorScheme ??
+        ColorScheme.fromSeed(
+            seedColor: _seedColor, brightness: Brightness.dark);
     return ThemeData(
       colorScheme: defaultDarkColorScheme,
       useMaterial3: true,

--- a/lib/widgets/variable_text.dart
+++ b/lib/widgets/variable_text.dart
@@ -1,0 +1,32 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+
+/// - Variable 폰트 파일을 Font Variation으로 적용한 텍스트 위젯입니다.
+/// - `wght: double` 인자로 폰트의 굵기를 조절할 수 있습니다.
+/// - [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0] 중 선택할 수 있습니다.
+class VariableText extends StatelessWidget {
+  final String value;
+  final double size;
+  final Color? color;
+  final double? wght;
+
+  const VariableText({
+    Key? key,
+    required this.value,
+    required this.size,
+    this.color,
+    this.wght,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      value,
+      style: TextStyle(
+        color: color,
+        fontSize: size,
+        fontVariations: <FontVariation>[FontVariation('wght', wght!)],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Cold boot로 Flutter 에뮬레이터를 통해 작업을 진행했습니다.
- #2 이슈에서 인풋, 아웃풋 메세지 위젯은 다음 이슈로 이동했습니다.
- 아래 목록은 현재 Pull request에 포함된 구성 요소입니다.
```[list]
1. Root screen 위젯
2. Header content 위젯
3. Body content 위젯
4. Tips content 위젯
```
- 그리고 스냅샷을 통해서 전체적인 화면을 확인할 수 있습니다.
---
<div align="center">
 <p align="center"> Snapshot </p>
 <img width="300" alt="PetmilyGPT_스타일링_스크린샷" src="https://user-images.githubusercontent.com/26790710/231143830-eb80edd6-b029-497b-aea9-b6f41a0a3c32.png">
</div>
